### PR TITLE
add react native support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @digitalbazaar/eddsa-rdfc-2022-cryptosuite Changelog
 
-## 1.3.0 - TBD
+## 1.3.0 - 2025-04-30
 
 ### Added
 - Add support for react native by switching @digitalbazaar dependencies to @digitalcredential forks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/eddsa-rdfc-2022-cryptosuite Changelog
 
+## 1.3.0 - TBD
+
+### Added
+- Add support for react native by switching @digitalbazaar dependencies to @digitalcredential forks
+
 ## 1.2.0 - 2024-11-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# EdDSA RDFC 2022 Data Integrity Cryptosuite _(@digitalbazaar/eddsa-rdfc-2022-cryptosuite)_
+# EdDSA RDFC 2022 Data Integrity Cryptosuite _(@digitalcredentials/eddsa-rdfc-2022-cryptosuite)_
 
-[![Build status](https://img.shields.io/github/actions/workflow/status/digitalbazaar/eddsa-rdfc-2022-cryptosuite/main.yml)](https://github.com/digitalbazaar/eddsa-rdfc-2022-cryptosuite/actions?query=workflow%3A%22Node.js+CI%22)
-[![Coverage status](https://img.shields.io/codecov/c/github/digitalbazaar/eddsa-rdfc-2022-cryptosuite)](https://codecov.io/gh/digitalbazaar/eddsa-rdfc-2022-cryptosuite)
-[![NPM Version](https://img.shields.io/npm/v/@digitalbazaar/eddsa-rdfc-2022-cryptosuite.svg)](https://npm.im/@digitalbazaar/eddsa-rdfc-2022-cryptosuite)
+[![Build status](https://img.shields.io/github/actions/workflow/status/digitalcredentials/eddsa-rdfc-2022-cryptosuite/main.yml)](https://github.com/digitalcredentials/eddsa-rdfc-2022-cryptosuite/actions?query=workflow%3A%22Node.js+CI%22)
+[![NPM Version](https://img.shields.io/npm/v/@digitalcredentials/eddsa-rdfc-2022-cryptosuite.svg)](https://npm.im/@digitalcredentials/eddsa-rdfc-2022-cryptosuite)
 
 > EdDSA 2022 Data Integrity Cryptosuite for use with jsonld-signatures.
+
+NOTE: this is a fork of [`@digitalbazaar/eddsa-rdfc-2022-cryptosuite`](https://github.com/digitalbazaar/eddsa-rdfc-2022-cryptosuite) to add support for react native. The only fundamental change is to replace the @digitalbazaar dependencies with @digitalcredential forks that use react native compatible cryptographic libraries when used in react native.
 
 ## Table of Contents
 
@@ -18,7 +19,7 @@
 
 ## Background
 
-For use with https://github.com/digitalbazaar/jsonld-signatures v11.0 and above.
+For use with https://github.com/digitalcredentials/jsonld-signatures v11.0 and above.
 
 See also related specs:
 
@@ -35,13 +36,13 @@ TBD
 To install from NPM:
 
 ```
-npm install @digitalbazaar/eddsa-rdfc-2022-cryptosuite
+npm install @digitalcredentials/eddsa-rdfc-2022-cryptosuite
 ```
 
 To install locally (for development):
 
 ```
-git clone https://github.com/digitalbazaar/eddsa-rdfc-2022-cryptosuite.git
+git clone https://github.com/digitalcredentials/eddsa-rdfc-2022-cryptosuite.git
 cd eddsa-rdfc-2022-cryptosuite
 npm install
 ```
@@ -52,11 +53,11 @@ The following code snippet provides a complete example of digitally signing
 a verifiable credential using this library:
 
 ```javascript
-import * as Ed25519Multikey from '@digitalbazaar/ed25519-multikey';
-import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
+import * as Ed25519Multikey from '@digitalcredentials/ed25519-multikey';
+import {DataIntegrityProof} from '@digitalcredentials/data-integrity';
 import {cryptosuite as eddsaRdfc2022CryptoSuite} from
-  '@digitalbazaar/eddsa-rdfc-2022-cryptosuite';
-import jsigs from 'jsonld-signatures';
+  '@digitalcredentials/eddsa-rdfc-2022-cryptosuite';
+import jsigs from '@digitalcredentials/jsonld-signatures';
 const {purposes: {AssertionProofPurpose}} = jsigs;
 
 
@@ -152,18 +153,9 @@ const signedCredential = await jsigs.sign(unsignedCredential, {
 
 ## Contribute
 
-See [the contribute file](https://github.com/digitalbazaar/bedrock/blob/master/CONTRIBUTING.md)!
-
 PRs accepted.
 
 If editing the Readme, please conform to the
 [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
 
-## Commercial Support
 
-Commercial support for this library is available upon request from
-Digital Bazaar: support@digitalbazaar.com
-
-## License
-
-[New BSD License (3-clause)](LICENSE) © 2023 Digital Bazaar

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ NOTE: this is a fork of [`@digitalbazaar/eddsa-rdfc-2022-cryptosuite`](https://g
 - [Install](#install)
 - [Usage](#usage)
 - [Contribute](#contribute)
-- [Commercial Support](#commercial-support)
 - [License](#license)
 
 ## Background
@@ -158,4 +157,6 @@ PRs accepted.
 If editing the Readme, please conform to the
 [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
 
+## License
 
+[MIT License](LICENSE.md) © 2025 Digital Credentials Consortium.

--- a/lib/canonize.js
+++ b/lib/canonize.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2023-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import * as rdfCanonize from 'rdf-canonize';
-import jsonld from 'jsonld';
+import jsonld from '@digitalcredentials/jsonld';
 
 export async function canonize(input, options) {
   // convert to RDF dataset and do canonicalization

--- a/lib/createVerifier.js
+++ b/lib/createVerifier.js
@@ -1,7 +1,7 @@
 /*!
  * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
  */
-import * as Ed25519Multikey from '@digitalbazaar/ed25519-multikey';
+import * as Ed25519Multikey from '@digitalcredentials/ed25519-multikey';
 
 export async function createVerifier({verificationMethod}) {
   const key = await Ed25519Multikey.from(verificationMethod);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalcredentials/eddsa-rdfc-2022-cryptosuite",
-  "version": "1.2.1-0",
+  "version": "1.2.1-beta.1",
   "description": "An EdDSA-RDFC-2022 Data Integrity cryptosuite for use with jsonld-signatures.",
   "homepage": "https://github.com/digitalcredentials/eddsa-rdfc-2022-cryptosuite",
   "repository": {
@@ -14,9 +14,9 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "@digitalcredentials/ed25519-multikey": "file:../ed25519-multikey",
+    "@digitalcredentials/ed25519-multikey": "^1.3.3-beta.1",
     "@digitalcredentials/jsonld": "^9.0.0",
-    "@digitalcredentials/rdf-canonize": "^1.0.0"
+    "rdf-canonize": "^4.0.1"
   },
   "devDependencies": {
     "@digitalbazaar/data-integrity": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalcredentials/eddsa-rdfc-2022-cryptosuite",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0",
   "description": "An EdDSA-RDFC-2022 Data Integrity cryptosuite for use with jsonld-signatures.",
   "homepage": "https://github.com/digitalcredentials/eddsa-rdfc-2022-cryptosuite",
   "repository": {
@@ -14,7 +14,7 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "@digitalcredentials/ed25519-multikey": "^1.4.0-beta.1",
+    "@digitalcredentials/ed25519-multikey": "^1.4.0",
     "@digitalcredentials/jsonld": "^9.0.0",
     "rdf-canonize": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -14,14 +14,13 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "@digitalbazaar/ed25519-multikey": "^1.0.0",
+    "@digitalcredentials/ed25519-multikey": "file:../ed25519-multikey",
     "@digitalcredentials/jsonld": "^9.0.0",
     "@digitalcredentials/rdf-canonize": "^1.0.0"
   },
   "devDependencies": {
     "@digitalbazaar/data-integrity": "^2.0.0",
     "@digitalbazaar/data-integrity-context": "^2.0.0",
-    "@digitalbazaar/ed25519-multikey": "^1.0.0",
     "@digitalbazaar/ed25519-verification-key-2018": "^4.0.0",
     "@digitalbazaar/ed25519-verification-key-2020": "^4.1.0",
     "@digitalbazaar/multikey-context": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalcredentials/eddsa-rdfc-2022-cryptosuite",
-  "version": "1.2.1-beta.3",
+  "version": "1.3.0",
   "description": "An EdDSA-RDFC-2022 Data Integrity cryptosuite for use with jsonld-signatures.",
   "homepage": "https://github.com/digitalcredentials/eddsa-rdfc-2022-cryptosuite",
   "repository": {
@@ -14,8 +14,7 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "@digitalcredentials/ed25519-multikey": "^1.3.3-beta.1",
-    "@digitalcredentials/eddsa-rdfc-2022-cryptosuite": "^1.2.1-beta.2",
+    "@digitalcredentials/ed25519-multikey": "^1.3.3-beta.4",
     "@digitalcredentials/jsonld": "^9.0.0",
     "rdf-canonize": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalcredentials/eddsa-rdfc-2022-cryptosuite",
-  "version": "1.3.0",
+  "version": "1.3.0-beta.1",
   "description": "An EdDSA-RDFC-2022 Data Integrity cryptosuite for use with jsonld-signatures.",
   "homepage": "https://github.com/digitalcredentials/eddsa-rdfc-2022-cryptosuite",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalcredentials/eddsa-rdfc-2022-cryptosuite",
-  "version": "1.2.1-beta.2",
+  "version": "1.2.1-beta.3",
   "description": "An EdDSA-RDFC-2022 Data Integrity cryptosuite for use with jsonld-signatures.",
   "homepage": "https://github.com/digitalcredentials/eddsa-rdfc-2022-cryptosuite",
   "repository": {
@@ -15,6 +15,7 @@
   ],
   "dependencies": {
     "@digitalcredentials/ed25519-multikey": "^1.3.3-beta.1",
+    "@digitalcredentials/eddsa-rdfc-2022-cryptosuite": "^1.2.1-beta.2",
     "@digitalcredentials/jsonld": "^9.0.0",
     "rdf-canonize": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalcredentials/eddsa-rdfc-2022-cryptosuite",
-  "version": "1.2.1-beta.1",
+  "version": "1.2.1-beta.2",
   "description": "An EdDSA-RDFC-2022 Data Integrity cryptosuite for use with jsonld-signatures.",
   "homepage": "https://github.com/digitalcredentials/eddsa-rdfc-2022-cryptosuite",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@digitalbazaar/eddsa-rdfc-2022-cryptosuite",
+  "name": "@digitalcredentials/eddsa-rdfc-2022-cryptosuite",
   "version": "1.2.1-0",
   "description": "An EdDSA-RDFC-2022 Data Integrity cryptosuite for use with jsonld-signatures.",
-  "homepage": "https://github.com/digitalbazaar/eddsa-rdfc-2022-cryptosuite",
+  "homepage": "https://github.com/digitalcredentials/eddsa-rdfc-2022-cryptosuite",
   "repository": {
     "type": "git",
-    "url": "https://github.com/digitalbazaar/eddsa-rdfc-2022-cryptosuite"
+    "url": "https://github.com/digitalcredentials/eddsa-rdfc-2022-cryptosuite"
   },
   "license": "BSD-3-Clause",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/digitalcredentials/eddsa-rdfc-2022-cryptosuite"
   },
-  "license": "BSD-3-Clause",
+  "license": "MIT",
   "type": "module",
   "exports": "./lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   ],
   "dependencies": {
     "@digitalbazaar/ed25519-multikey": "^1.0.0",
-    "jsonld": "^8.1.0",
-    "rdf-canonize": "^4.0.1"
+    "@digitalcredentials/jsonld": "^9.0.0",
+    "@digitalcredentials/rdf-canonize": "^1.0.0"
   },
   "devDependencies": {
     "@digitalbazaar/data-integrity": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "@digitalcredentials/ed25519-multikey": "^1.3.3-beta.4",
+    "@digitalcredentials/ed25519-multikey": "^1.4.0-beta.1",
     "@digitalcredentials/jsonld": "^9.0.0",
     "rdf-canonize": "^4.0.1"
   },

--- a/test/Eddsa2022Cryptosuite.spec.js
+++ b/test/Eddsa2022Cryptosuite.spec.js
@@ -11,13 +11,13 @@ import {
   credential,
   ed25519MultikeyKeyPair
 } from './mock-data.js';
-import {DataIntegrityProof} from '@digitalcredentials/data-integrity';
+import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
 import {
   Ed25519VerificationKey2018
-} from '@digitalcredentials/ed25519-verification-key-2018';
+} from '@digitalbazaar/ed25519-verification-key-2018';
 import {
   Ed25519VerificationKey2020
-} from '@digitalcredentials/ed25519-verification-key-2020';
+} from '@digitalbazaar/ed25519-verification-key-2020';
 import {
   cryptosuite as eddsa2022CryptoSuite
 } from '../lib/index.js';

--- a/test/Eddsa2022Cryptosuite.spec.js
+++ b/test/Eddsa2022Cryptosuite.spec.js
@@ -11,13 +11,13 @@ import {
   credential,
   ed25519MultikeyKeyPair
 } from './mock-data.js';
-import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
+import {DataIntegrityProof} from '@digitalcredentials/data-integrity';
 import {
   Ed25519VerificationKey2018
-} from '@digitalbazaar/ed25519-verification-key-2018';
+} from '@digitalcredentials/ed25519-verification-key-2018';
 import {
   Ed25519VerificationKey2020
-} from '@digitalbazaar/ed25519-verification-key-2020';
+} from '@digitalcredentials/ed25519-verification-key-2020';
 import {
   cryptosuite as eddsa2022CryptoSuite
 } from '../lib/index.js';

--- a/test/Eddsa2022Cryptosuite.spec.js
+++ b/test/Eddsa2022Cryptosuite.spec.js
@@ -6,7 +6,7 @@ import {expect} from 'chai';
 import jsigs from 'jsonld-signatures';
 const {purposes: {AssertionProofPurpose}} = jsigs;
 
-import * as Ed25519Multikey from '@digitalbazaar/ed25519-multikey';
+import * as Ed25519Multikey from '@digitalcredentials/ed25519-multikey';
 import {
   credential,
   ed25519MultikeyKeyPair

--- a/test/test-vectors.spec.js
+++ b/test/test-vectors.spec.js
@@ -3,7 +3,7 @@
  */
 import * as Ed25519Multikey from '@digitalcredentials/ed25519-multikey';
 import {cryptosuite} from '../lib/index.js';
-import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
+import {DataIntegrityProof} from '@digitalcredentials/data-integrity';
 import {expect} from 'chai';
 import jsigs from 'jsonld-signatures';
 import {loader} from './documentLoader.js';

--- a/test/test-vectors.spec.js
+++ b/test/test-vectors.spec.js
@@ -1,7 +1,7 @@
 /*!
  * Copyright (c) 2023-2024 Digital Bazaar, Inc. All rights reserved.
  */
-import * as Ed25519Multikey from '@digitalbazaar/ed25519-multikey';
+import * as Ed25519Multikey from '@digitalcredentials/ed25519-multikey';
 import {cryptosuite} from '../lib/index.js';
 import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
 import {expect} from 'chai';

--- a/test/test-vectors.spec.js
+++ b/test/test-vectors.spec.js
@@ -3,7 +3,7 @@
  */
 import * as Ed25519Multikey from '@digitalcredentials/ed25519-multikey';
 import {cryptosuite} from '../lib/index.js';
-import {DataIntegrityProof} from '@digitalcredentials/data-integrity';
+import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
 import {expect} from 'chai';
 import jsigs from 'jsonld-signatures';
 import {loader} from './documentLoader.js';


### PR DESCRIPTION
Replaces @digitalbazaar dependencies with @digitalcredential forks that in turn provide react native compatible crypto when used in react native.